### PR TITLE
Don't push container image by default

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Login to ghcr.io
       uses: docker/login-action@v1
-      if: ${{ github.ref == join('refs/heads/', github.event.repository.default_branch) }}
+      if: false
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -40,7 +40,7 @@ jobs:
 
     - name: Login to DockerHub
       uses: docker/login-action@v1
-      if: ${{ github.ref == join('refs/heads/', github.event.repository.default_branch) }}
+      if: false
       with:
         username: sksat
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: ${{ github.ref == join('refs/heads/', github.event.repository.default_branch) }}
+        push: false
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha


### PR DESCRIPTION
そもそもpushしてほしくない場合もあるし，ghcr.io以外はsecrets設定しないと使えんわけでテンプレートとしては正しくない