### PR TITLE
Bye set-output

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Get Rust toolchain
         id: toolchain
         run: |
-          echo -n "::set-output name=toolchain::"
-          awk -F'[ ="]+' '$1 == "channel" { print $2 }' rust-toolchain
+          echo "toolchain="$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' rust-toolchain) >> $GITHUB_OUTPUT
 
       - uses: actions-rs/toolchain@v1.0.7
         with:


### PR DESCRIPTION
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.com/sksat/cargo-chef-docker/pull/85