### PR TITLE
Use awk only for output toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get Rust toolchain
         id: toolchain
         run: |
-          echo "toolchain="$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' rust-toolchain) >> $GITHUB_OUTPUT
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> $GITHUB_OUTPUT
 
       - uses: actions-rs/toolchain@v1.0.7
         with:


### PR DESCRIPTION
- toolchain を取得する step で `awk` のみを使う
- ワンライナーの複雑さが減る
- `awk` がコケた時にこの step がコケるようになる