### PR TITLE
Run Rust CI workflow on all Pull Request

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,12 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-    paths:
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain'
-      - '.github/workflows/rust.yml'
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
- CI をケチらない
- branch protection rule に突っ込みたいがち